### PR TITLE
Add GIF previews to Amplitude project coming-soon modals.

### DIFF
--- a/css/work.css
+++ b/css/work.css
@@ -1895,9 +1895,35 @@ a.project-tile:hover,
   padding: 3rem 2rem;
   text-align: center;
   box-sizing: border-box;
+  gap: 0.625rem;
 }
 
 .project-modal-placeholder[hidden] {
+  display: none !important;
+}
+
+.project-modal-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(100%, 32rem);
+  margin-top: 1.5rem;
+}
+
+.project-modal-gif {
+  display: block;
+  width: 100%;
+  max-width: 32rem;
+  max-height: min(38vh, 22rem);
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 8px 28px rgba(26, 35, 48, 0.08);
+  object-fit: contain;
+  background: var(--color-bg-alt);
+}
+
+.project-modal-gif[hidden] {
   display: none !important;
 }
 
@@ -1908,11 +1934,11 @@ a.project-tile:hover,
   line-height: 1.25;
   letter-spacing: -0.01em;
   color: var(--color-text);
-  margin: 0 0 0.75rem;
+  margin: 0;
 }
 
 .project-modal-coming-soon {
-  font-size: var(--text-body);
+  font-size: var(--text-body-sm);
   color: var(--color-text-muted);
   margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -455,6 +455,9 @@
       <div class="project-modal-placeholder" id="project-modal-placeholder" hidden>
         <h2 class="project-modal-title" id="project-modal-title"></h2>
         <p class="project-modal-coming-soon">Coming soon</p>
+        <div class="project-modal-preview">
+          <img class="project-modal-gif" id="project-modal-gif" src="" alt="" hidden />
+        </div>
       </div>
     </div>
   </div>
@@ -465,12 +468,13 @@
       var iframe = document.getElementById('project-modal-iframe');
       var placeholder = document.getElementById('project-modal-placeholder');
       var titleEl = document.getElementById('project-modal-title');
+      var gifEl = document.getElementById('project-modal-gif');
       var closeBtn = overlay.querySelector('.project-modal-close');
       var panel = overlay.querySelector('.project-modal-panel');
       var backdrop = overlay.querySelector('.project-modal-backdrop');
       var closeDuration = 400;
 
-      function openModal(src, title) {
+      function openModal(src, title, trigger) {
         if (src) {
           iframe.removeAttribute('hidden');
           placeholder.setAttribute('hidden', '');
@@ -483,6 +487,20 @@
           iframe.src = 'about:blank';
           placeholder.removeAttribute('hidden');
           titleEl.textContent = title || '';
+
+          var previewImg = trigger && trigger.querySelector('img[data-gif]');
+          if (gifEl && previewImg) {
+            var gif = previewImg.getAttribute('data-gif');
+            var still = previewImg.getAttribute('src');
+            var useStill = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            gifEl.src = useStill && still ? still : gif || still || '';
+            gifEl.alt = title ? title + ' preview' : '';
+            gifEl.removeAttribute('hidden');
+          } else if (gifEl) {
+            gifEl.setAttribute('hidden', '');
+            gifEl.src = '';
+            gifEl.alt = '';
+          }
         }
 
         overlay.setAttribute('aria-hidden', 'false');
@@ -507,6 +525,11 @@
           iframe.src = 'about:blank';
           placeholder.setAttribute('hidden', '');
           titleEl.textContent = '';
+          if (gifEl) {
+            gifEl.setAttribute('hidden', '');
+            gifEl.src = '';
+            gifEl.alt = '';
+          }
         }, closeDuration);
       }
 
@@ -522,7 +545,7 @@
           if (e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ') return;
           e.preventDefault();
           e.stopPropagation();
-          openModal(null, trigger.getAttribute('data-modal-title'));
+          openModal(null, trigger.getAttribute('data-modal-title'), trigger);
         }
 
         trigger.addEventListener('click', activate);


### PR DESCRIPTION
Show each tile's preview animation in the placeholder modal as a balanced empty state below the title and coming-soon message, with reduced-motion fallback to still images.