### PR TITLE
Improve mobile UX and instrument Amplitude Session Replay

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,8 @@
   </style>
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/agrity-legacy.html
+++ b/agrity-legacy.html
@@ -18,7 +18,8 @@
 
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/agrity.html
+++ b/agrity.html
@@ -14,7 +14,8 @@
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/bluebear-legacy.html
+++ b/bluebear-legacy.html
@@ -18,7 +18,8 @@
 
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/bluebear.html
+++ b/bluebear.html
@@ -13,7 +13,8 @@
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/chorushomepage-legacy.html
+++ b/chorushomepage-legacy.html
@@ -18,7 +18,8 @@
 
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/chorushomepage.html
+++ b/chorushomepage.html
@@ -14,7 +14,8 @@
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/chorusmobile-legacy.html
+++ b/chorusmobile-legacy.html
@@ -19,7 +19,8 @@
 
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/chorusmobile.html
+++ b/chorusmobile.html
@@ -14,7 +14,8 @@
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/css/work.css
+++ b/css/work.css
@@ -2174,8 +2174,27 @@ body.modal-open {
     --space-3xl: 6rem;
   }
 
+  html,
+  body.work-page {
+    overflow-x: hidden;
+    overscroll-behavior-x: none;
+    max-width: 100%;
+  }
+
   .work-header {
     padding: var(--space-sm) var(--space-md);
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .work-layout,
+  .work-main {
+    max-width: 100%;
+  }
+
+  .work-hero {
+    max-width: 100%;
+    overflow-x: clip;
   }
 
   .work-hero,

--- a/css/work.css
+++ b/css/work.css
@@ -2301,6 +2301,25 @@ body.modal-open {
     text-overflow: clip;
     min-height: 0;
   }
+
+  /* Secondary tiles: full-bleed images collide with overlay copy on narrow screens */
+  .experience-projects-row--secondary .project-desc {
+    display: none;
+  }
+
+  .experience-projects-row--secondary .project-tile {
+    background-position: center bottom;
+  }
+
+  .experience-projects-row--secondary .project-tile-inner {
+    padding-bottom: 0.75rem;
+    background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.88) 0%,
+      rgba(255, 255, 255, 0.55) 60%,
+      rgba(255, 255, 255, 0) 100%
+    );
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/css/work.css
+++ b/css/work.css
@@ -2226,7 +2226,17 @@ body.modal-open {
   }
 
   .work-hero .hero-profile-deck {
-    --profile-card-size: 5.25rem;
+    --profile-card-gap: 0.5rem;
+    /* Fit all four cards inside the viewport so expand never causes horizontal scroll */
+    --profile-card-size: min(
+      5.25rem,
+      calc((100vw - 2 * var(--space-md) - 3 * var(--profile-card-gap)) / 4)
+    );
+  }
+
+  /* Keep layout width fixed; only the absolute cards fan out */
+  .work-hero .hero-profile-deck.is-expanded {
+    width: var(--profile-card-size);
   }
 
   .work-hero .hero-profile-card {

--- a/css/work.css
+++ b/css/work.css
@@ -572,7 +572,7 @@ body.work-page .section-label {
 
 /* ----- Experience section ----- */
 .work-experience {
-  padding: var(--space-lg) var(--space-xl) var(--space-3xl);
+  padding: var(--space-lg) var(--space-xl) var(--space-2xl);
   max-width: var(--max-content);
   margin: 0 auto;
 }
@@ -609,6 +609,14 @@ body.work-page .section-label {
 .work-experience .experience-item:first-child {
   border-top: none;
   padding-top: 0;
+}
+
+.work-experience .experience-item:last-child {
+  padding-bottom: 0;
+}
+
+.work-experience .experience-item:last-child .experience-desc {
+  margin-bottom: 0;
 }
 
 .work-experience .experience-dates {

--- a/css/work.css
+++ b/css/work.css
@@ -342,7 +342,16 @@ body.work-page .section-label {
   cursor: pointer;
 }
 
-.work-hero .hero-profile-deck:hover {
+@media (hover: hover) and (pointer: fine) {
+  .work-hero .hero-profile-deck:hover {
+    width: calc(
+      var(--profile-card-count) * var(--profile-card-size) +
+      (var(--profile-card-count) - 1) * var(--profile-card-gap)
+    );
+  }
+}
+
+.work-hero .hero-profile-deck.is-expanded {
   width: calc(
     var(--profile-card-count) * var(--profile-card-size) +
     (var(--profile-card-count) - 1) * var(--profile-card-gap)
@@ -397,22 +406,44 @@ body.work-page .section-label {
   transition-delay: 0ms;
 }
 
-.work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(1) {
+@media (hover: hover) and (pointer: fine) {
+  .work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(1) {
+    transform: translateX(calc(0 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
+    transition-delay: 0ms;
+  }
+
+  .work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(2) {
+    transform: translateX(calc(1 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
+    transition-delay: 45ms;
+  }
+
+  .work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(3) {
+    transform: translateX(calc(2 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
+    transition-delay: 90ms;
+  }
+
+  .work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(4) {
+    transform: translateX(calc(3 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
+    transition-delay: 135ms;
+  }
+}
+
+.work-hero .hero-profile-deck.is-expanded .hero-profile-card:nth-child(1) {
   transform: translateX(calc(0 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
   transition-delay: 0ms;
 }
 
-.work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(2) {
+.work-hero .hero-profile-deck.is-expanded .hero-profile-card:nth-child(2) {
   transform: translateX(calc(1 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
   transition-delay: 45ms;
 }
 
-.work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(3) {
+.work-hero .hero-profile-deck.is-expanded .hero-profile-card:nth-child(3) {
   transform: translateX(calc(2 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
   transition-delay: 90ms;
 }
 
-.work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(4) {
+.work-hero .hero-profile-deck.is-expanded .hero-profile-card:nth-child(4) {
   transform: translateX(calc(3 * (var(--profile-card-size) + var(--profile-card-gap)))) rotate(0deg);
   transition-delay: 135ms;
 }
@@ -423,11 +454,13 @@ body.work-page .section-label {
     transition: none;
   }
 
-  .work-hero .hero-profile-deck:hover {
+  .work-hero .hero-profile-deck:hover,
+  .work-hero .hero-profile-deck.is-expanded {
     width: var(--profile-card-size);
   }
 
-  .work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(n) {
+  .work-hero .hero-profile-deck:hover .hero-profile-card:nth-child(n),
+  .work-hero .hero-profile-deck.is-expanded .hero-profile-card:nth-child(n) {
     transform: none;
     transition-delay: 0ms;
   }
@@ -2249,6 +2282,11 @@ body.modal-open {
     transform: none;
     box-shadow: none;
     opacity: 1;
+  }
+
+  .experience-projects-row--primary .project-tile--featured.is-active {
+    outline: 2px solid rgba(26, 35, 48, 0.12);
+    outline-offset: 2px;
   }
 
   .experience-projects-row--primary .project-tile--featured.is-active .project-tile-visual img {

--- a/fun.html
+++ b/fun.html
@@ -6,7 +6,8 @@
   <title>Redirecting to Photography…</title>
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/index-legacy.html
+++ b/index-legacy.html
@@ -18,7 +18,8 @@
 	<link rel="stylesheet" href="css/animated-bg.css"> <!-- Resource style -->
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
   <link rel="stylesheet" href="css/draw-easter-egg.css">
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
-  <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <!-- Amplitude: Analytics, Session Replay, Web Experiment, Feature Flags -->
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/index.html
+++ b/index.html
@@ -183,14 +183,6 @@
                 </span>
               </p>
               <p class="experience-desc">Designed Agrity, a bid tracking console for complex agricultural workflows.</p>
-              <div class="experience-projects-row experience-projects-row--secondary experience-projects-row--single">
-                <a href="agrity.html" id="agrity" class="project-tile project-tile--agrity" data-modal-src="agrity.html">
-                  <div class="project-tile-inner">
-                    <span class="project-label">Agrity Bid Tracking Console</span>
-                    <p class="project-desc">Create and manage your agricultural bids</p>
-                  </div>
-                </a>
-              </div>
             </div>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <main class="work-main">
       <!-- Hero -->
       <section class="work-hero">
-        <div class="hero-profile-deck" aria-label="Profile photos">
+        <div class="hero-profile-deck" role="button" tabindex="0" aria-expanded="false" aria-label="View profile photos">
           <div class="hero-profile-card">
             <img src="images/profile.png" alt="Fayyaz Mukarram" />
           </div>
@@ -214,7 +214,7 @@
           <li class="musings-item">
             <span class="musings-category">Vibe coding</span>
             <div class="musings-detail">
-              <p class="musings-desc">Vibe coding games for the nostalgia and sharing with my younger cousins.</p>
+              <p class="musings-desc">Building games and side projects for the nostalgia</p>
               <div class="musings-chips">
                 <a href="dx-ball.html" class="musings-chip" target="_blank" rel="noopener">
                   <span class="musings-chip-label">DX Ball</span>
@@ -300,52 +300,102 @@
           });
         }
 
+        function activate(activeIdx) {
+          items.forEach(function(el, i) {
+            var distance = Math.abs(i - activeIdx);
+            var shift = lift * Math.pow(falloff, distance);
+            el.style.transitionTimingFunction = easeIn;
+            el.style.setProperty('--shift', shift.toFixed(3) + 'px');
+            el.style.setProperty('--scale-active', i === activeIdx ? String(scale) : '1');
+          });
+        }
+
         items.forEach(function(item, activeIdx) {
           item.addEventListener('mouseenter', function() {
-            items.forEach(function(el, i) {
-              var distance = Math.abs(i - activeIdx);
-              var shift = lift * Math.pow(falloff, distance);
-              el.style.transitionTimingFunction = easeIn;
-              el.style.setProperty('--shift', shift.toFixed(3) + 'px');
-              el.style.setProperty('--scale-active', i === activeIdx ? String(scale) : '1');
-            });
+            activate(activeIdx);
           });
+          item.addEventListener('focus', function() {
+            activate(activeIdx);
+          });
+          item.addEventListener('blur', reset);
         });
 
         group.addEventListener('mouseleave', reset);
       })();
 
-      (function projectGifHover() {
-        var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        if (reducedMotion) return;
+      (function profileDeckInteraction() {
+        var deck = document.querySelector('.hero-profile-deck');
+        if (!deck) return;
 
-        document.querySelectorAll('img.project-tile-gif').forEach(function(img) {
-          var gif = img.getAttribute('data-gif');
-          var still = img.getAttribute('src');
-          if (!gif || !still) return;
+        var finePointer = window.matchMedia('(hover: hover) and (pointer: fine)');
+        var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-          var tile = img.closest('.project-tile');
-          if (!tile) return;
+        function setExpanded(open) {
+          if (reducedMotion.matches) open = false;
+          deck.classList.toggle('is-expanded', open);
+          deck.setAttribute('aria-expanded', open ? 'true' : 'false');
+        }
 
-          var preloader = new Image();
-          preloader.src = gif;
+        function toggleExpanded() {
+          setExpanded(!deck.classList.contains('is-expanded'));
+        }
 
-          tile.addEventListener('mouseenter', function() {
-            var gifSrc = gif + '?' + Date.now();
-            var loader = new Image();
-            loader.onload = function() {
-              img.src = gifSrc;
-            };
-            loader.src = gifSrc;
-          });
+        deck.addEventListener('click', function(e) {
+          e.stopPropagation();
+          if (finePointer.matches) return;
+          toggleExpanded();
+        });
 
-          tile.addEventListener('mouseleave', function() {
-            img.src = still;
-          });
+        deck.addEventListener('keydown', function(e) {
+          if (e.key !== 'Enter' && e.key !== ' ') return;
+          e.preventDefault();
+          toggleExpanded();
+        });
+
+        document.addEventListener('click', function() {
+          if (!finePointer.matches) setExpanded(false);
+        });
+
+        finePointer.addEventListener('change', function() {
+          setExpanded(false);
         });
       })();
 
-      (function experienceProjectRowHover() {
+      (function projectTileInteractions() {
+        var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        var finePointer = window.matchMedia('(hover: hover) and (pointer: fine)');
+
+        function playGif(tile) {
+          if (reducedMotion) return;
+          var img = tile.querySelector('img.project-tile-gif');
+          if (!img) return;
+          var gif = img.getAttribute('data-gif');
+          var still = img.getAttribute('data-still') || img.getAttribute('src');
+          if (!gif || !still) return;
+          img.setAttribute('data-still', still);
+          var gifSrc = gif + '?' + Date.now();
+          var loader = new Image();
+          loader.onload = function() {
+            img.src = gifSrc;
+          };
+          loader.src = gifSrc;
+        }
+
+        function stopGif(tile) {
+          var img = tile.querySelector('img.project-tile-gif');
+          if (!img) return;
+          var still = img.getAttribute('data-still');
+          if (still) img.src = still;
+        }
+
+        document.querySelectorAll('img.project-tile-gif').forEach(function(img) {
+          var gif = img.getAttribute('data-gif');
+          if (gif) {
+            var preloader = new Image();
+            preloader.src = gif;
+          }
+        });
+
         document.querySelectorAll('.experience-projects-row').forEach(function(row) {
           var tiles = Array.prototype.slice.call(row.querySelectorAll('.project-tile'));
           if (!tiles.length) return;
@@ -356,7 +406,10 @@
           function applyActive(index) {
             row.setAttribute('data-active', String(index));
             tiles.forEach(function(tile, i) {
-              tile.classList.toggle('is-active', i === index);
+              var active = i === index;
+              tile.classList.toggle('is-active', active);
+              if (active) playGif(tile);
+              else stopGif(tile);
             });
           }
 
@@ -365,6 +418,7 @@
             row.classList.remove('is-entering');
             tiles.forEach(function(tile) {
               tile.classList.remove('is-active');
+              stopGif(tile);
             });
           }
 
@@ -396,17 +450,70 @@
             applyActive(index);
           }
 
-          tiles.forEach(function(tile, index) {
-            tile.addEventListener('mouseenter', function() {
-              setActive(index);
+          function bindFinePointer() {
+            tiles.forEach(function(tile, index) {
+              tile.addEventListener('mouseenter', tile._onEnter = function() {
+                setActive(index);
+              });
             });
-          });
+            row.addEventListener('mouseleave', row._onLeave = function() {
+              collapseTimer = setTimeout(function() {
+                setActive(-1);
+              }, 120);
+            });
+          }
 
-          row.addEventListener('mouseleave', function() {
-            collapseTimer = setTimeout(function() {
-              setActive(-1);
-            }, 120);
-          });
+          function unbindFinePointer() {
+            tiles.forEach(function(tile) {
+              if (tile._onEnter) tile.removeEventListener('mouseenter', tile._onEnter);
+            });
+            if (row._onLeave) row.removeEventListener('mouseleave', row._onLeave);
+          }
+
+          function bindTouchPointer() {
+            tiles.forEach(function(tile, index) {
+              tile.addEventListener('click', tile._onTap = function(e) {
+                var alreadyActive = tile.classList.contains('is-active');
+                var hasGif = !!tile.querySelector('img.project-tile-gif');
+                var canExpand = window.matchMedia('(min-width: 769px)').matches;
+                var shouldPreview = hasGif || canExpand;
+
+                if (!alreadyActive && shouldPreview) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setActive(index);
+                  return;
+                }
+
+                // Open immediately when there's nothing to preview, or on second tap.
+                setTimeout(function() {
+                  setActive(-1);
+                }, 0);
+              }, true);
+            });
+
+            document.addEventListener('click', row._onDocTap = function(e) {
+              if (!row.contains(e.target)) setActive(-1);
+            });
+          }
+
+          function unbindTouchPointer() {
+            tiles.forEach(function(tile) {
+              if (tile._onTap) tile.removeEventListener('click', tile._onTap, true);
+            });
+            if (row._onDocTap) document.removeEventListener('click', row._onDocTap);
+          }
+
+          function syncPointerMode() {
+            unbindFinePointer();
+            unbindTouchPointer();
+            clearActive();
+            if (finePointer.matches) bindFinePointer();
+            else bindTouchPointer();
+          }
+
+          syncPointerMode();
+          finePointer.addEventListener('change', syncPointerMode);
         });
       })();
 

--- a/js/amplitude-setup.js
+++ b/js/amplitude-setup.js
@@ -1,12 +1,21 @@
-// Amplitude: Analytics init, Web Experiment, and Feature Flags
+// Amplitude: Analytics init, Session Replay, Web Experiment, and Feature Flags
 (function () {
     'use strict';
 
     var API_KEY = '1ce437130da0f6268eb2efbf0375ee14';
     var DEPLOYMENT_KEY = 'client-Vfe82ZGCD6aZVoLOXJA1WosPUStnWJHd';
 
-    if (window.AMPLITUDE_SESSION_REPLAY && window.sessionReplay) {
+    if (!window.amplitude) {
+        console.error('[Amplitude] Browser SDK failed to load');
+        return;
+    }
+
+    // Install Session Replay before init so it shares analytics deviceId/sessionId.
+    // Do not pass deviceId here — overriding it causes device ID mismatch.
+    if (window.sessionReplay && typeof window.sessionReplay.plugin === 'function') {
         window.amplitude.add(window.sessionReplay.plugin({ sampleRate: 1 }));
+    } else {
+        console.warn('[Amplitude] Session Replay plugin not loaded');
     }
 
     window.amplitude.init(API_KEY, {

--- a/mobileredesign-legacy.html
+++ b/mobileredesign-legacy.html
@@ -18,7 +18,8 @@
 
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/mobileredesign.html
+++ b/mobileredesign.html
@@ -14,7 +14,8 @@
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/photography-legacy.html
+++ b/photography-legacy.html
@@ -20,7 +20,8 @@
 
 		<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/photography.html
+++ b/photography.html
@@ -13,7 +13,8 @@
   <link rel="stylesheet" href="css/photography.css">
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/quickpolls-legacy.html
+++ b/quickpolls-legacy.html
@@ -18,7 +18,8 @@
 
 	<link rel="stylesheet" href="css/portfolio-gate.css">
 	<!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+	<script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
 	<script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
 	<script src="js/experiment-browser.min.js"></script>
 	<script src="js/amplitude-setup.js"></script>

--- a/quickpolls.html
+++ b/quickpolls.html
@@ -14,7 +14,8 @@
 
   <link rel="stylesheet" href="css/portfolio-gate.css">
   <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+  <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
   <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
   <script src="js/experiment-browser.min.js"></script>
   <script src="js/amplitude-setup.js"></script>

--- a/test-analytics.html
+++ b/test-analytics.html
@@ -6,11 +6,10 @@
     <title>Analytics Test Page</title>
     
     <!-- Amplitude: Analytics, Web Experiment, Feature Flags -->
-    <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.7-min.js.gz"></script>
-    <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.1.9-min.js.gz"></script>
+    <script src="https://cdn.amplitude.com/libs/analytics-browser-2.44.6-min.js.gz"></script>
+    <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.33.2-min.js.gz"></script>
     <script src="https://cdn.amplitude.com/script/1ce437130da0f6268eb2efbf0375ee14.experiment.js"></script>
     <script src="js/experiment-browser.min.js"></script>
-    <script>window.AMPLITUDE_SESSION_REPLAY = true;</script>
     <script src="js/amplitude-setup.js"></script>
     <script src="js/analytics.js"></script>
     


### PR DESCRIPTION
## Summary
- Hide the Agrity case study tile from the homepage while keeping the Summer 2016 LSVP timeline snippet, and tune Experience/Musings spacing.
- Make hero profile and project hover interactions work on mobile via touch (tap-to-expand, first-tap preview / second-tap open), and fix secondary tile text overlapping images.
- Prevent horizontal scroll/nav shift when the profile deck expands on mobile.
- Instrument Amplitude Session Replay sitewide: load the plugin before init, upgrade the Browser SDK, and avoid deviceId overrides so replays link correctly to analytics.

## Test plan
- [ ] On mobile/narrow viewport: tap profile photos to expand/collapse; confirm Work/Musings/About nav does not shift and page cannot scroll horizontally
- [ ] On mobile: first tap an Amplitude project tile previews (GIF/active), second tap opens the modal; Chorus/Quick Polls open on first tap
- [ ] On mobile: secondary case study cards show labels without description text overlapping the image
- [ ] Desktop hover behaviors for profile deck and project tiles still work
- [ ] Hard-refresh; Network shows Session Replay plugin loaded and replay requests firing; Amplitude setup checker no longer reports missing replay data / deviceId mismatch (use incognito if needed)


Made with [Cursor](https://cursor.com)